### PR TITLE
Fix: 프로필 변경이 안되는 이슈 수정

### DIFF
--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -131,12 +131,12 @@ exports.updateProfile = async (req, res) => {
   try {
     const { name } = req.body;
 
-    if (!name || name.trim().length === 0) {
-      return res.status(400).json({
-        success: false,
-        message: '이름을 입력해주세요.'
-      });
-    }
+    // if (!name || name.trim().length === 0) {
+    //   return res.status(400).json({
+    //     success: false,
+    //     message: '이름을 입력해주세요.'
+    //   });
+    // }
 
     const user = await User.findById(req.user.id);
     if (!user) {
@@ -146,7 +146,7 @@ exports.updateProfile = async (req, res) => {
       });
     }
 
-    user.name = name.trim();
+    user.name = name?.trim() ?? user.name;
     await user.save();
 
     res.json({


### PR DESCRIPTION
FE에서 닉네임 수정과 비밀번호 수정을 따로 전송하는데,
BE에서 닉네임을 필수 파라미터로 받아 에러 발생